### PR TITLE
Reanomenar acció de correcció ortogràfica a `spellcheck`

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,16 +1,14 @@
-name: build # Nom de l'automatització
+name: spellcheck # Nom de l'automatització
 on: # Events que disparen l'automatització
-  push:
-    branches:
-      - 'main' # Quan es fa un push a la branca main
-    tags:
-      - '**' # Quan es crea qualsevol etiqueta
   pull_request:
+    # Tipus d'events sobre la pull request
+    types: ['opened', 'edited', 'reopened', 'synchronize', 'ready_for_review']
     branches:
       - '**' # Quan s'obri un pull request a qualsevol branca
 
 jobs: # Llista de tasques a executar
   documents: # Nom de la tasca
+    if: github.event.pull_request.draft == false # Condició per executar la tasca
     runs-on: ubuntu-latest # Sistema operatiu on s'executarà la tasca
     env: # Variables d'entorn
       DICPATH: .hunspell/
@@ -30,7 +28,7 @@ jobs: # Llista de tasques a executar
           sudo apt update
           sudo apt install hunspell -y
       - name: Build documents # Acció per compilar la documentació
-        run: mkdocs build --clean
+        run: CI=false mkdocs build --clean
 
       - name: Download dictionary # Acció per descarregar el diccionari que s'utilitzarà en el corrector ortogràfic
         run: |

--- a/docs/apunts/06_projectes/03_actions.md
+++ b/docs/apunts/06_projectes/03_actions.md
@@ -82,8 +82,8 @@ Cada tasca té les següents seccions:
         ```
 
     === "Correcció ortogràfica"
-        ```yaml title=".github/workflows/build.yml"
-        --8<-- ".github/workflows/build.yml"
+        ```yaml title=".github/workflows/spellcheck.yml"
+        --8<-- ".github/workflows/spellcheck.yml"
         ```
 
 ### Execució d'una automatització
@@ -92,7 +92,7 @@ quan es compleixen les condicions definides en la secció `on`
 de la configuració.
 
 No obstant, podem configurar una tasca perquè es puga executar manualment.
-Hem de definir un esdeveniment `workflow_dispatch` en la secció `on` de la configuració.
+Hem de definir un esdeveniment `workflow_dispatch` en la secció `on` de la configuració
 que permet llançar la tasca des de l'apartat __:material-arrow-right-drop-circle-outline: Actions__
 del repositori.
 


### PR DESCRIPTION
- Reanomenar `build.yml` a `spellcheck.yml`.
- Sols llançar en les Pull Requests.
- No llançar l'acció en els esborranys.